### PR TITLE
feat: camera, smooth zoom in/out mouse scroll (linux/win)

### DIFF
--- a/src/linux_x64/pixie.asm
+++ b/src/linux_x64/pixie.asm
@@ -150,10 +150,12 @@ _start:
 
 
 public gravity
+public targetZoom
 
 section '.data' writeable
 frameTime       dd 0x00000000               ;   0.0
 gravity         dd 0x44750000               ; 980.0
+targetZoom      dd 0x3fe66666
 
 section '.bss' writeable align 16
 align 16

--- a/src/windows_x64/include/consts.inc
+++ b/src/windows_x64/include/consts.inc
@@ -1,26 +1,24 @@
 
-STATE_IDLE          equ 0
-STATE_RUN           equ 1
-STATE_JUMP          equ 2
-STATE_FALL          equ 3
-STATE_BREAK         equ 4
-STATE_COUNT         equ 5
+STATE_IDLE              equ 0
+STATE_RUN               equ 1
+STATE_JUMP              equ 2
+STATE_FALL              equ 3
+STATE_BREAK             equ 4
+STATE_COUNT             equ 5
 
-DIRECTION_LEFT      equ -1
-DIRECTION_RIGHT     equ 1
+DIRECTION_LEFT          equ -1
+DIRECTION_RIGHT         equ 1
 
-KEY_RIGHT           equ 262
-KEY_LEFT            equ 263
-KEY_UP              equ 265
-KEY_Z               equ 90
-KEY_X               equ 88
-KEY_C               equ 67
+KEY_RIGHT               equ 262
+KEY_LEFT                equ 263
+KEY_UP                  equ 265
+KEY_C                   equ 67
 
-ANIMATION_STATES_CAP equ 16
-ANIMATION_LOOKUP_CAP equ 8
+ANIMATION_STATES_CAP    equ 16
+ANIMATION_LOOKUP_CAP    equ 8
 
-PARALLAX_LAYER_CAP equ 16
+PARALLAX_LAYER_CAP      equ 16
 
-MASK_NEG            equ 0x80000000
-MASK_ABS            equ 0x7FFFFFFF
+MASK_NEG                equ 0x80000000
+MASK_ABS                equ 0x7FFFFFFF
 

--- a/src/windows_x64/main.asm
+++ b/src/windows_x64/main.asm
@@ -147,10 +147,12 @@ main:
 
 
 public gravity
+public targetZoom
 
 section '.data' data readable writeable
 frameTime       dd 0x00000000
 gravity         dd 0x44750000
+targetZoom      dd 0x3fe66666
 
 section '.bss' data readable writeable align 16
 align 16


### PR DESCRIPTION
- added mouse wheel input for zoom control
- smooth zoom transition for better camera feel
- prevented excessive zoom-in/out limits
- CTRL + C for reset camera zoom level